### PR TITLE
Add missing pugixml dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,7 +7,7 @@ url="https://github.com/mdk97/aitrack-linux"
 source=("git+https://github.com/mdk97/aitrack-linux")
 license=("MIT")
 sha256sums=('SKIP')
-depends=("opencv" "fmt" "spdlog" "qt5-base" "qt5-x11extras" "openmp" "vtk" "glew" "hdf5")
+depends=("opencv" "fmt" "spdlog" "qt5-base" "qt5-x11extras" "openmp" "vtk" "glew" "hdf5" "pugixml")
 makedepends=("curl" "gzip" "tar" "make" "gcc" "opencv" "fmt" "spdlog" "qt5-base" "qt5-x11extras" "openmp" "vtk")
 install=aitrack.install
 prepare() {


### PR DESCRIPTION
Today I've started getting the following error message when trying to start `aitrack` and installing the `pugixml` package allowed me to build and run the software again.

```
aitrack: error while loading shared libraries: libpugixml.so.1: cannot open shared object file: No such file or directory
```